### PR TITLE
Aggregate autoscaling metrics on controller

### DIFF
--- a/bazel/python.bzl
+++ b/bazel/python.bzl
@@ -114,3 +114,22 @@ def py_test_run_all_notebooks(include, exclude, allow_empty=False, **kwargs):
             args = ["--find-recursively", "--path", file],
             **kwargs
         )
+
+def py_test_module_list_with_env_variants(files, env_variants, size="medium", **kwargs):
+    """Create multiple py_test_module_list targets with different environment variable configurations.
+
+    Args:
+        files: List of test files to run
+        env_variants: Dict where keys are variant names and values are dicts containing
+                     'env' and 'name_suffix' keys
+        size: Test size
+        **kwargs: Additional arguments passed to py_test_module_list
+    """
+    for variant_name, variant_config in env_variants.items():
+        py_test_module_list(
+            size = size,
+            files = files,
+            env = variant_config.get("env", {}),
+            name_suffix = variant_config.get("name_suffix", "_{}".format(variant_name)),
+            **kwargs
+        )

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -506,3 +506,8 @@ if RAY_SERVE_THROUGHPUT_OPTIMIZED:
 # This is used to detect and warn about long RPC latencies
 # between the controller and the replicas.
 RAY_SERVE_RPC_LATENCY_WARNING_THRESHOLD_MS = 2000
+
+# Feature flag to aggregate metrics at the controller instead of the replicas or handles.
+RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER = get_env_bool(
+    "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER", "0"
+)

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//bazel:python.bzl", "py_test_module_list")
+load("//bazel:python.bzl", "py_test_module_list", "py_test_module_list_with_env_variants")
 
 py_library(
     name = "conftest",
@@ -317,17 +317,44 @@ py_test(
 
 # ----- TEST FEATURE FLAGS -----
 
-# Test autoscaling with metrics collected from replica instead of handle.
-py_test(
-    name = "test_autoscaling_policy_with_metr_disab",
+# Test autoscaling with different metric collection configurations
+py_test_module_list_with_env_variants(
     size = "large",
-    srcs = ["test_autoscaling_policy.py"],
-    env = {
-        "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
-        # Make sure queued metrics are cleared out quickly.
-        "RAY_SERVE_HANDLE_METRIC_PUSH_INTERVAL_S": "0.1",
+    env_variants = {
+        "with_metr_disab": {
+            "env": {
+                "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
+                # Make sure queued metrics are cleared out quickly.
+                "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
+            },
+            "name_suffix": "_with_metr_disab",
+        },
+        "with_metr_agg_at_controller": {
+            "env": {
+                "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
+                # Make sure queued metrics are cleared out quickly.
+                "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
+            },
+            "name_suffix": "_with_metr_agg_at_controller",
+        },
+        "with_metr_agg_at_controller_and_metr_on_replicas": {
+            "env": {
+                "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
+                "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
+                # Make sure queued metrics are cleared out quickly.
+                "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
+            },
+            "name_suffix": "_with_metr_agg_at_controller_and_metr_on_replicas",
+        },
     },
-    main = "test_autoscaling_policy.py",
+    files = [
+        "test_autoscaling_policy.py",
+        "test_cluster.py",
+        "test_deploy.py",
+        "test_deployment_scheduler.py",
+        "test_standalone_3.py",
+        "test_target_capacity.py",
+    ],
     tags = [
         "autoscaling",
         "exclusive",

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -1551,6 +1551,7 @@ def test_e2e_scale_up_down_basic_with_custom_policy(serve_instance_with_signal, 
             "upscale_delay_s": 0,
             "policy": policy,
             "metrics_interval_s": 0.1,
+            "look_back_period_s": 1,
         },
         # We will send over a lot of queries. This will make sure replicas are
         # killed quickly during cleanup.
@@ -1572,11 +1573,13 @@ def test_e2e_scale_up_down_basic_with_custom_policy(serve_instance_with_signal, 
     wait_for_condition(check_num_replicas_eq, name="A", target=2)
     print("Scaled up to 2 replicas.")
 
-    ray.get(signal.send.remote(clear=True))
+    ray.get(signal.send.remote())
     wait_for_condition(lambda: ray.get(signal.cur_num_waiters.remote()) == 0)
+    ray.get(signal.send.remote(clear=True))
     [handle.remote() for _ in range(70)]
     wait_for_condition(check_num_replicas_eq, name="A", target=3)
-    ray.get(signal.send.remote(clear=True))
+    ray.get(signal.send.remote())
+    wait_for_condition(lambda: ray.get(signal.cur_num_waiters.remote()) == 0)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/BUILD.bazel
+++ b/python/ray/serve/tests/unit/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_library")
-load("//bazel:python.bzl", "py_test_module_list", "py_test_run_all_subdirectory")
+load("//bazel:python.bzl", "py_test_module_list", "py_test_module_list_with_env_variants", "py_test_run_all_subdirectory")
 
 py_library(
     name = "conftest",
@@ -41,18 +41,39 @@ py_test_module_list(
     ],
 )
 
-py_test_module_list(
-    size = "medium",
-    env = {
-        "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
-        "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
+py_test_module_list_with_env_variants(
+    env_variants = {
+        "with_metr_disab": {
+            "env": {
+                "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
+                "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
+            },
+            "name_suffix": "_with_metr_disab",
+        },
+        "with_metr_agg_at_controller": {
+            "env": {
+                "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
+                "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "1",
+                "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
+            },
+            "name_suffix": "_with_metr_agg_at_controller",
+        },
+        "with_metr_agg_at_controller_and_metr_on_replicas": {
+            "env": {
+                "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
+                "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
+                "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
+            },
+            "name_suffix": "_with_metr_agg_at_controller_and_metr_on_replicas",
+        },
     },
     files = [
         "test_autoscaling_policy.py",
+        "test_controller.py",
+        "test_deployment_scheduler.py",
         "test_deployment_state.py",
         "test_router.py",
     ],
-    name_suffix = "_with_metr_disab",
     tags = [
         "no_windows",
         "team:serve",

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -2849,7 +2849,7 @@ class TestAutoscaling:
                 metrics={
                     RUNNING_REQUESTS_KEY: {
                         replica._actor.replica_id: [
-                            TimeStampedValue(timer.time(), req_per_replica)
+                            TimeStampedValue(timer.time() - 0.1, req_per_replica)
                         ]
                         for replica in replicas
                     }
@@ -2864,7 +2864,7 @@ class TestAutoscaling:
                     aggregated_metrics={RUNNING_REQUESTS_KEY: req_per_replica},
                     metrics={
                         RUNNING_REQUESTS_KEY: [
-                            TimeStampedValue(timer.time(), req_per_replica)
+                            TimeStampedValue(timer.time() - 0.1, req_per_replica)
                         ]
                     },
                     timestamp=timer.time(),
@@ -3035,7 +3035,9 @@ class TestAutoscaling:
                 },
                 metrics={
                     RUNNING_REQUESTS_KEY: {
-                        replica._actor.replica_id: [TimeStampedValue(timer.time(), 2)]
+                        replica._actor.replica_id: [
+                            TimeStampedValue(timer.time() - 0.1, 2)
+                        ]
                         for replica in replicas
                     }
                 },
@@ -3047,7 +3049,9 @@ class TestAutoscaling:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
                     aggregated_metrics={RUNNING_REQUESTS_KEY: 2},
-                    metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time(), 2)]},
+                    metrics={
+                        RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time() - 0.1, 2)]
+                    },
                     timestamp=timer.time(),
                 )
                 asm.record_request_metrics_for_replica(replica_metric_report)
@@ -3127,7 +3131,9 @@ class TestAutoscaling:
                 },
                 metrics={
                     RUNNING_REQUESTS_KEY: {
-                        replica._actor.replica_id: [TimeStampedValue(timer.time(), 1)]
+                        replica._actor.replica_id: [
+                            TimeStampedValue(timer.time() - 0.1, 1)
+                        ]
                         for replica in replicas
                     }
                 },
@@ -3139,7 +3145,9 @@ class TestAutoscaling:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
                     aggregated_metrics={RUNNING_REQUESTS_KEY: 1},
-                    metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time(), 1)]},
+                    metrics={
+                        RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time() - 0.1, 1)]
+                    },
                     timestamp=timer.time(),
                 )
                 asm.record_request_metrics_for_replica(replica_metric_report)
@@ -3232,7 +3240,9 @@ class TestAutoscaling:
                 },
                 metrics={
                     RUNNING_REQUESTS_KEY: {
-                        replica._actor.replica_id: [TimeStampedValue(timer.time(), 1)]
+                        replica._actor.replica_id: [
+                            TimeStampedValue(timer.time() - 0.1, 1)
+                        ]
                         for replica in replicas
                     }
                 },
@@ -3244,7 +3254,9 @@ class TestAutoscaling:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
                     aggregated_metrics={RUNNING_REQUESTS_KEY: 1},
-                    metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time(), 1)]},
+                    metrics={
+                        RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time() - 0.1, 1)]
+                    },
                     timestamp=timer.time(),
                 )
                 asm.record_request_metrics_for_replica(replica_metric_report)
@@ -3536,7 +3548,7 @@ class TestAutoscaling:
             metrics={
                 RUNNING_REQUESTS_KEY: {
                     ds._replicas.get()[0]._actor.replica_id: [
-                        TimeStampedValue(timer.time(), 2)
+                        TimeStampedValue(timer.time() - 0.1, 2)
                     ]
                 }
             },
@@ -3643,7 +3655,7 @@ class TestAutoscaling:
             metrics={
                 RUNNING_REQUESTS_KEY: {
                     ds1._replicas.get()[0]._actor.replica_id: [
-                        TimeStampedValue(timer.time(), 2)
+                        TimeStampedValue(timer.time() - 0.1, 2)
                     ]
                 }
             },

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1,18 +1,16 @@
 import asyncio
 import sys
-from collections import defaultdict
 
 import pytest
 
 from ray._common.test_utils import async_wait_for_condition
 from ray.serve._private.metrics_utils import (
-    QUEUED_REQUESTS_KEY,
     InMemoryMetricsStore,
     MetricsPusher,
     TimeStampedValue,
-    _bucket_latest_by_window,
-    _merge_two_timeseries,
+    merge_instantaneous_total,
     merge_timeseries_dicts,
+    time_weighted_average,
 )
 from ray.serve._private.test_utils import MockAsyncTimer
 
@@ -221,363 +219,340 @@ class TestInMemoryMetricsStore:
         assert len(s.data["m2"]) == 2 and s.data["m2"] == s._get_datapoints("m2", 1.1)
         assert len(s.data["m3"]) == 1 and s.data["m3"] == s._get_datapoints("m3", 1.1)
 
-    def test_merge_metrics_stores(self):
-        s1 = InMemoryMetricsStore()
-        s2 = InMemoryMetricsStore()
-        s3 = InMemoryMetricsStore()
-        s1.add_metrics_point(
-            {"m1": 1, "m2": 2, "m3": 3, QUEUED_REQUESTS_KEY: 1}, timestamp=1
-        )
-        s2.add_metrics_point({"m1": 2, "m2": 2, QUEUED_REQUESTS_KEY: 1}, timestamp=2)
-        s3.add_metrics_point({"m2": 10, QUEUED_REQUESTS_KEY: 10}, timestamp=2)
-        merged = merge_timeseries_dicts(s1.data, s2.data, s3.data, window_s=1)
 
-        assert_timeseries_equal(
-            merged["m1"], [TimeStampedValue(1, 1), TimeStampedValue(2, 2)]
-        )
-        assert_timeseries_equal(
-            merged["m2"], [TimeStampedValue(1, 2), TimeStampedValue(2, 12)]
-        )
-        assert_timeseries_equal(merged["m3"], [TimeStampedValue(1, 3)])
-        assert_timeseries_equal(
-            merged[QUEUED_REQUESTS_KEY],
-            [TimeStampedValue(1, 1), TimeStampedValue(2, 11)],
-        )
+class TestInstantaneousMerge:
+    """Test the new instantaneous merge functionality."""
 
-        s4 = InMemoryMetricsStore()
-        s4.add_metrics_point(
-            {"m1": 100, "m2": 100, "m3": 100, QUEUED_REQUESTS_KEY: 10}, timestamp=0
-        )
-
-        merged = merge_timeseries_dicts(s1.data, s2.data, s3.data, s4.data, window_s=2)
-
-        # With window_s=2 and window start alignment:
-        # Window boundaries: [0,2), [2,4), etc.
-        # timestamp=0 (s4) and timestamp=1 (s1) -> window 0
-        # timestamp=2 (s2, s3) -> window 1
-        assert_timeseries_equal(
-            merged["m1"],
-            [TimeStampedValue(0, 101), TimeStampedValue(2, 2)],  # 100+1=101, then 2
-        )
-        assert_timeseries_equal(
-            merged["m2"],
-            [
-                TimeStampedValue(0, 102),
-                TimeStampedValue(2, 12),
-            ],  # 100+2=102, then 2+10=12
-        )
-        assert_timeseries_equal(
-            merged["m3"], [TimeStampedValue(0, 103)]  # 100+3=103, no data in window 1
-        )
-        assert_timeseries_equal(
-            merged[QUEUED_REQUESTS_KEY],
-            [TimeStampedValue(0, 11), TimeStampedValue(2, 11)],  # 10+1=11, then 1+10=11
-        )
-
-        s1_s2 = merge_timeseries_dicts(s1.data, s2.data, window_s=1)
-        s2_s1 = merge_timeseries_dicts(s2.data, s1.data, window_s=1)
-        s1_s2_s3_s4 = merge_timeseries_dicts(
-            s1.data, s2.data, s3.data, s4.data, window_s=1
-        )
-        s4_s1_s3_s2 = merge_timeseries_dicts(
-            s4.data, s1.data, s3.data, s2.data, window_s=1
-        )
-
-        # dict equality -> compare per-key time series
-        for k in s1_s2:
-            assert_timeseries_equal(s1_s2[k], s2_s1[k])
-        for k in s1_s2_s3_s4:
-            assert_timeseries_equal(s1_s2_s3_s4[k], s4_s1_s3_s2[k])
-
-        a1_none = merge_timeseries_dicts(s1.data, defaultdict(list), window_s=1)
-        for k in a1_none:
-            assert_timeseries_equal(a1_none[k], s1.data[k])
-
-    def test_bucket_latest_by_window_basic(self):
-        """Test basic functionality of _bucket_latest_by_window."""
-        series = [
-            TimeStampedValue(1.0, 10.0),
-            TimeStampedValue(1.5, 15.0),  # Same window as 1.0, should overwrite
-            TimeStampedValue(3.0, 30.0),
-        ]
-
-        # With window_s=1.0, start=0.0
-        buckets = _bucket_latest_by_window(series, start=0.0, window_s=1.0)
-
-        # Window 1: timestamps 1.0-2.0, latest value should be 15.0
-        # Window 3: timestamp 3.0-4.0, value should be 30.0
-        expected = {1: 15.0, 3: 30.0}
-        assert buckets == expected
-
-    def test_bucket_latest_by_window_empty(self):
-        """Test _bucket_latest_by_window with empty series."""
-        buckets = _bucket_latest_by_window([], start=0.0, window_s=1.0)
-        assert buckets == {}
-
-    def test_bucket_latest_by_window_single_value(self):
-        """Test _bucket_latest_by_window with single value."""
-        series = [TimeStampedValue(2.5, 25.0)]
-        buckets = _bucket_latest_by_window(series, start=0.0, window_s=1.0)
-        assert buckets == {2: 25.0}
-
-    def test_bucket_latest_by_window_negative_timestamps(self):
-        """Test _bucket_latest_by_window with negative timestamps."""
-        series = [
-            TimeStampedValue(-1.5, 10.0),
-            TimeStampedValue(-0.5, 20.0),
-            TimeStampedValue(0.5, 30.0),
-        ]
-        buckets = _bucket_latest_by_window(series, start=-2.0, window_s=1.0)
-        # Window 0: -1.5 (index = (-1.5 - (-2.0)) // 1.0 = 0.5 // 1.0 = 0)
-        # Window 1: -0.5 (index = (-0.5 - (-2.0)) // 1.0 = 1.5 // 1.0 = 1)
-        # Window 2: 0.5 (index = (0.5 - (-2.0)) // 1.0 = 2.5 // 1.0 = 2)
-        expected = {0: 10.0, 1: 20.0, 2: 30.0}
-        assert buckets == expected
-
-    def test_bucket_latest_by_window_very_small_window(self):
-        """Test _bucket_latest_by_window with very small windows."""
-        series = [
-            TimeStampedValue(1.001, 10.0),
-            TimeStampedValue(1.002, 20.0),  # Different window
-        ]
-        buckets = _bucket_latest_by_window(series, start=1.0, window_s=0.001)
-        # With window_s=0.001:
-        # 1.001: (1.001 - 1.0) // 0.001 = 1.0 => window 1, but floor division gives 0
-        # 1.002: (1.002 - 1.0) // 0.001 = 2.0 => window 2
-        expected = {
-            0: 10.0,
-            2: 20.0,
-        }  # Corrected based on actual floor division behavior
-        assert buckets == expected
-
-    def test_merge_two_timeseries_both_empty(self):
-        """Test _merge_two_timeseries with both series empty."""
-        result = _merge_two_timeseries([], [], window_s=1.0)
+    def test_merge_instantaneous_total_empty(self):
+        """Test merge_instantaneous_total with empty input."""
+        result = merge_instantaneous_total([])
         assert result == []
 
-    def test_merge_two_timeseries_one_empty(self):
-        """Test _merge_two_timeseries with one series empty."""
-        t1 = [TimeStampedValue(1.0, 10.0), TimeStampedValue(2.0, 20.0)]
+        result = merge_instantaneous_total([[], []])
+        assert result == []
 
-        result1 = _merge_two_timeseries(t1, [], window_s=1.0)
-        result2 = _merge_two_timeseries([], t1, window_s=1.0)
-
-        # Results should be the same regardless of order
-        assert len(result1) == len(result2) == 2
-        assert_timeseries_equal(result1, result2)
-
-    def test_merge_two_timeseries_overlapping_windows(self):
-        """Test _merge_two_timeseries with values in overlapping time windows."""
-        t1 = [TimeStampedValue(1.0, 10.0), TimeStampedValue(1.5, 15.0)]
-        t2 = [TimeStampedValue(1.3, 13.0), TimeStampedValue(1.8, 18.0)]
-
-        result = _merge_two_timeseries(t1, t2, window_s=1.0)
-
-        # With window_s=1.0 and earliest=1.0:
-        # start = 1.0 // 1.0 * 1.0 = 1.0
-        # Window boundaries are [1.0, 2.0), [2.0, 3.0), etc.
-        # All values (1.0, 1.3, 1.5, 1.8) fall in window [1.0, 2.0)
-        # So we get 1 window
-        assert len(result) == 1
-
-        # Window 0: latest from t1 is 15.0 (1.5 > 1.0), latest from t2 is 18.0 (1.8 > 1.3), sum: 33.0
-        assert result[0].value == 33.0
-
-    def test_merge_two_timeseries_zero_window(self):
-        """Test _merge_two_timeseries with zero window size."""
-        t1 = [TimeStampedValue(1.0, 10.0)]
-        t2 = [TimeStampedValue(1.0, 20.0)]
-
-        # Zero window should raise ValueError
-        with pytest.raises(ValueError, match="window_s must be positive, got 0"):
-            _merge_two_timeseries(t1, t2, window_s=0.0)
-
-    def test_merge_two_timeseries_negative_window(self):
-        """Test _merge_two_timeseries with negative window size."""
-        t1 = [TimeStampedValue(1.0, 10.0)]
-        t2 = [TimeStampedValue(1.0, 20.0)]
-
-        # Negative window should raise ValueError
-        with pytest.raises(ValueError, match="window_s must be positive, got -1"):
-            _merge_two_timeseries(t1, t2, window_s=-1.0)
-
-    def test_merge_two_timeseries_very_small_window(self):
-        """Test _merge_two_timeseries with very small window."""
-        t1 = [TimeStampedValue(1.0, 10.0)]
-        t2 = [TimeStampedValue(1.0001, 20.0)]
-
-        result = _merge_two_timeseries(t1, t2, window_s=0.0001)
-
-        # With very small window, these should be in different buckets
-        assert len(result) == 2
-
-    def test_merge_two_timeseries_large_window(self):
-        """Test _merge_two_timeseries with very large window."""
-        t1 = [TimeStampedValue(1.0, 10.0), TimeStampedValue(100.0, 15.0)]
-        t2 = [TimeStampedValue(50.0, 20.0), TimeStampedValue(200.0, 25.0)]
-
-        result = _merge_two_timeseries(t1, t2, window_s=1000.0)
-
-        # All values should be in the same window
-        assert len(result) == 1
-        # Latest from t1: 15.0, latest from t2: 25.0, sum: 40.0
-        assert result[0].value == 40.0
-
-    def test_merge_two_timeseries_duplicate_timestamps(self):
-        """Test _merge_two_timeseries with duplicate timestamps in same series."""
-        t1 = [
-            TimeStampedValue(1.0, 10.0),
-            TimeStampedValue(1.0, 15.0),  # Duplicate timestamp
+    def test_merge_instantaneous_total_single_replica(self):
+        """Test merge_instantaneous_total with single replica."""
+        series = [
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(2.0, 7.0),
+            TimeStampedValue(3.0, 3.0),
         ]
-        t2 = [TimeStampedValue(1.0, 20.0)]
+        result = merge_instantaneous_total([series])
 
-        result = _merge_two_timeseries(t1, t2, window_s=1.0)
-
-        # Latest from t1 should be 15.0, t2 should be 20.0, sum: 35.0
-        assert len(result) == 1
-        assert result[0].value == 35.0
-
-    def test_merge_two_timeseries_floating_point_precision(self):
-        """Test _merge_two_timeseries with floating point precision edge cases."""
-        # Test with timestamps that might have precision issues
-        t1 = [TimeStampedValue(0.1 + 0.2, 10.0)]  # 0.30000000000000004
-        t2 = [TimeStampedValue(0.3, 20.0)]
-
-        result = _merge_two_timeseries(t1, t2, window_s=0.01)
-
-        # These should be in the same window due to floating point precision
-        # but let's verify the behavior
-        assert len(result) >= 1
-
-    def test_merge_timeseries_dicts_empty_dicts(self):
-        """Test merge_timeseries_dicts with empty dictionaries."""
-        result = merge_timeseries_dicts(
-            defaultdict(list), defaultdict(list), window_s=1.0
-        )
-        assert dict(result) == {}
-
-    def test_merge_timeseries_dicts_single_dict(self):
-        """Test merge_timeseries_dicts with single dictionary."""
-        data = defaultdict(list)
-        data["key1"] = [TimeStampedValue(1.0, 10.0)]
-
-        result = merge_timeseries_dicts(data, window_s=1.0)
-        # With windowing applied, the result should have the same values but potentially different timestamps
-        expected = defaultdict(list)
-        expected["key1"] = [TimeStampedValue(1.0, 10.0)]  # Window [1,2) starts at 1.0
-        assert_timeseries_equal(result["key1"], expected["key1"])
-
-    def test_merge_timeseries_dicts_no_common_keys(self):
-        """Test merge_timeseries_dicts with dictionaries having no common keys."""
-        d1 = defaultdict(list)
-        d1["key1"] = [TimeStampedValue(1.0, 10.0)]
-
-        d2 = defaultdict(list)
-        d2["key2"] = [TimeStampedValue(2.0, 20.0)]
-
-        result = merge_timeseries_dicts(d1, d2, window_s=1.0)
-
-        assert "key1" in result
-        assert "key2" in result
-        assert len(result["key1"]) == 1
-        assert len(result["key2"]) == 1
-
-    def test_merge_timeseries_dicts_many_stores(self):
-        """Test merge_timeseries_dicts with many stores."""
-        stores = []
-        for i in range(10):
-            store = defaultdict(list)
-            store["common_key"] = [TimeStampedValue(float(i), float(i * 10))]
-            stores.append(store)
-
-        result = merge_timeseries_dicts(*stores, window_s=1.0)
-
-        # Each value should be in its own window, sum should be 0+10+20+...+90 = 450
-        assert "common_key" in result
-        total_value = sum(point.value for point in result["common_key"])
-        assert total_value == 450.0
-
-    def test_merge_timeseries_dicts_zero_window(self):
-        """Test merge_timeseries_dicts with zero window size."""
-        d1 = defaultdict(list)
-        d1["key1"] = [TimeStampedValue(1.0, 10.0)]
-
-        d2 = defaultdict(list)
-        d2["key1"] = [TimeStampedValue(1.0, 20.0)]
-
-        # Zero window should raise ValueError
-        with pytest.raises(ValueError, match="window_s must be positive, got 0"):
-            merge_timeseries_dicts(d1, d2, window_s=0.0)
-
-    def test_merge_timeseries_dicts_negative_window(self):
-        """Test merge_timeseries_dicts with negative window size."""
-        d1 = defaultdict(list)
-        d1["key1"] = [TimeStampedValue(1.0, 10.0)]
-
-        # Negative window should raise ValueError
-        with pytest.raises(ValueError, match="window_s must be positive, got -1"):
-            merge_timeseries_dicts(d1, window_s=-1.0)
-
-    def test_merge_timeseries_dicts_window_alignment_consistency(self):
-        """Test that window alignment is consistent regardless of input order."""
-        # Create data that might expose window alignment issues
-        d1 = defaultdict(list)
-        d1["key1"] = [TimeStampedValue(1.1, 10.0)]
-
-        d2 = defaultdict(list)
-        d2["key1"] = [TimeStampedValue(1.9, 20.0)]
-
-        d3 = defaultdict(list)
-        d3["key1"] = [TimeStampedValue(2.1, 30.0)]
-
-        # Test different orderings
-        result1 = merge_timeseries_dicts(d1, d2, d3, window_s=1.0)
-        result2 = merge_timeseries_dicts(d3, d1, d2, window_s=1.0)
-        result3 = merge_timeseries_dicts(d2, d3, d1, window_s=1.0)
-
-        # Results should be the same regardless of order
-        assert_timeseries_equal(result1["key1"], result2["key1"])
-        assert_timeseries_equal(result1["key1"], result3["key1"])
-
-    def test_merge_stores_bug_fix_window_center_calculation(self):
-        """Test for potential bug in window center calculation."""
-        # This test checks if the window center calculation is correct
-        d1 = defaultdict(list)
-        d1["key1"] = [
-            TimeStampedValue(0.0, 10.0),
-            TimeStampedValue(1.0, 15.0),
-            TimeStampedValue(2.0, 20.0),
-            TimeStampedValue(4.0, 30.0),
-            TimeStampedValue(5.0, 40.0),
-        ]
-
-        result = merge_timeseries_dicts(d1, window_s=2.0)
-
-        # With window_s=2.0 and window start alignment:
-        # Window [0,2): timestamps 0.0, 1.0 -> latest value 15.0 at window start 0.0
-        # Window [2,4): timestamp 2.0 -> value 20.0 at window start 2.0
-        # Window [4,6): timestamps 4.0, 5.0 -> latest value 40.0 at window start 4.0
-        assert len(result["key1"]) == 3
         expected = [
-            TimeStampedValue(timestamp=0.0, value=15.0),  # Latest in window [0,2)
-            TimeStampedValue(timestamp=2.0, value=20.0),  # Value in window [2,4)
-            TimeStampedValue(timestamp=4.0, value=40.0),  # Latest in window [4,6)
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(2.0, 7.0),
+            TimeStampedValue(3.0, 3.0),
         ]
-        assert_timeseries_equal(result["key1"], expected)
+        assert_timeseries_equal(result, expected)
 
-    def test_merge_stores_preserves_value_precision(self):
-        """Test that merging preserves floating point precision of values."""
-        d1 = defaultdict(list)
-        d1["key1"] = [TimeStampedValue(1.0, 0.1)]
+    def test_merge_instantaneous_total_two_replicas(self):
+        """Test merge_instantaneous_total with two replicas."""
+        series1 = [
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(3.0, 7.0),
+        ]
+        series2 = [
+            TimeStampedValue(2.0, 3.0),
+            TimeStampedValue(4.0, 1.0),
+        ]
+        result = merge_instantaneous_total([series1, series2])
 
-        d2 = defaultdict(list)
-        d2["key1"] = [TimeStampedValue(1.0, 0.2)]
+        # Expected: t=1.0: +5 (total=5), t=2.0: +3 (total=8), t=3.0: +2 (total=10), t=4.0: -2 (total=8)
+        expected = [
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(2.0, 8.0),
+            TimeStampedValue(3.0, 10.0),
+            TimeStampedValue(4.0, 8.0),
+        ]
+        assert_timeseries_equal(result, expected)
 
-        result = merge_timeseries_dicts(d1, d2, window_s=1.0)
+    def test_merge_instantaneous_total_complex_scenario(self):
+        """Test complex scenario matching the autoscaling example."""
+        # r1: starts at 5 (t=0.2), changes to 7 (t=0.8), then 6 (t=1.5)
+        series1 = [
+            TimeStampedValue(0.2, 5.0),
+            TimeStampedValue(0.8, 7.0),
+            TimeStampedValue(1.5, 6.0),
+        ]
+        # r2: starts at 3 (t=0.1), changes to 4 (t=0.9), then 8 (t=1.2)
+        series2 = [
+            TimeStampedValue(0.1, 3.0),
+            TimeStampedValue(0.9, 4.0),
+            TimeStampedValue(1.2, 8.0),
+        ]
+        result = merge_instantaneous_total([series1, series2])
 
-        # 0.1 + 0.2 should equal 0.3 exactly
-        assert len(result["key1"]) == 1
-        assert abs(result["key1"][0].value - 0.3) < 1e-10
+        expected = [
+            TimeStampedValue(0.1, 3.0),  # r2 starts
+            TimeStampedValue(0.2, 8.0),  # r1 starts: 3+5=8
+            TimeStampedValue(0.8, 10.0),  # r1 changes: 8+(7-5)=10
+            TimeStampedValue(0.9, 11.0),  # r2 changes: 10+(4-3)=11
+            TimeStampedValue(1.2, 15.0),  # r2 changes: 11+(8-4)=15
+            TimeStampedValue(1.5, 14.0),  # r1 changes: 15+(6-7)=14
+        ]
+        assert_timeseries_equal(result, expected)
+
+    def test_time_weighted_average_empty(self):
+        """Test time_weighted_average with empty series."""
+        result = time_weighted_average([], 0.0, 1.0)
+        assert result is None
+
+    def test_time_weighted_average_no_overlap(self):
+        """Test time_weighted_average with no data overlap."""
+        series = [TimeStampedValue(2.0, 5.0)]
+        result = time_weighted_average(series, 0.0, 1.0)
+        assert result == 0.0  # Default value before first point
+
+    def test_time_weighted_average_constant_value(self):
+        """Test time_weighted_average with constant value."""
+        series = [TimeStampedValue(0.5, 10.0)]
+        result = time_weighted_average(series, 1.0, 2.0)
+        assert result == 10.0
+
+    def test_time_weighted_average_step_function(self):
+        """Test time_weighted_average with step function."""
+        series = [
+            TimeStampedValue(0.0, 5.0),
+            TimeStampedValue(1.0, 10.0),
+            TimeStampedValue(2.0, 15.0),
+        ]
+        # Average over [0.5, 1.5): 0.5s at value 5, 0.5s at value 10
+        result = time_weighted_average(series, 0.5, 1.5)
+        expected = (5.0 * 0.5 + 10.0 * 0.5) / 1.0
+        assert abs(result - expected) < 1e-10
+
+    def test_time_weighted_average_none_window_start(self):
+        """Test time_weighted_average with None window_start."""
+        series = [
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(2.0, 10.0),
+            TimeStampedValue(3.0, 15.0),
+        ]
+        # Should use full series from start (t=1.0) to window_end (t=2.5)
+        result = time_weighted_average(series, None, 2.5)
+        # 1.0s at value 5 (from 1.0 to 2.0), 0.5s at value 10 (from 2.0 to 2.5)
+        expected = (5.0 * 1.0 + 10.0 * 0.5) / 1.5
+        assert abs(result - expected) < 1e-10
+
+    def test_time_weighted_average_none_window_end(self):
+        """Test time_weighted_average with None window_end."""
+        series = [
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(2.0, 10.0),
+            TimeStampedValue(3.0, 15.0),
+        ]
+        # Should use from window_start (t=1.5) to end of series (t=3.0+1.0=4.0)
+        result = time_weighted_average(series, 1.5, None)
+        # 0.5s at value 5 (from 1.5 to 2.0), 1.0s at value 10 (from 2.0 to 3.0), 1.0s at value 15 (from 3.0 to 4.0)
+        expected = (5.0 * 0.5 + 10.0 * 1.0 + 15.0 * 1.0) / 2.5
+        assert abs(result - expected) < 1e-10
+
+    def test_time_weighted_average_both_none(self):
+        """Test time_weighted_average with both window_start and window_end None."""
+        series = [
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(2.0, 10.0),
+            TimeStampedValue(3.0, 15.0),
+        ]
+        # Should use full series from t=1.0 to t=3.0+1.0=4.0
+        result = time_weighted_average(series, None, None)
+        # 1.0s at value 5, 1.0s at value 10, 1.0s at value 15
+        expected = (5.0 * 1.0 + 10.0 * 1.0 + 15.0 * 1.0) / 3.0
+        assert abs(result - expected) < 1e-10
+
+    def test_time_weighted_average_single_point_none_bounds(self):
+        """Test time_weighted_average with single point and None bounds."""
+        series = [TimeStampedValue(2.0, 10.0)]
+        result = time_weighted_average(series, None, None)
+        # Single point with 1.0s duration (from 2.0 to 3.0)
+        assert result == 10.0
+
+    def test_time_weighted_average_custom_last_window_s(self):
+        """Test time_weighted_average with custom last_window_s parameter."""
+        series = [
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(2.0, 10.0),
+            TimeStampedValue(3.0, 15.0),
+        ]
+
+        # Test with last_window_s=2.0 (double the default)
+        result_2s = time_weighted_average(series, None, None, last_window_s=2.0)
+        # Should use from t=1.0 to t=3.0+2.0=5.0
+        # 1.0s at value 5 (from 1.0 to 2.0), 1.0s at value 10 (from 2.0 to 3.0), 2.0s at value 15 (from 3.0 to 5.0)
+        expected_2s = (5.0 * 1.0 + 10.0 * 1.0 + 15.0 * 2.0) / 4.0
+        assert abs(result_2s - expected_2s) < 1e-10
+
+        # Test with last_window_s=0.5 (half the default)
+        result_0_5s = time_weighted_average(series, None, None, last_window_s=0.5)
+        # Should use from t=1.0 to t=3.0+0.5=3.5
+        # 1.0s at value 5 (from 1.0 to 2.0), 1.0s at value 10 (from 2.0 to 3.0), 0.5s at value 15 (from 3.0 to 3.5)
+        expected_0_5s = (5.0 * 1.0 + 10.0 * 1.0 + 15.0 * 0.5) / 2.5
+        assert abs(result_0_5s - expected_0_5s) < 1e-10
+
+        # Test with window_start specified but window_end None - should still use last_window_s
+        result_with_start = time_weighted_average(series, 1.5, None, last_window_s=3.0)
+        # Should use from t=1.5 to t=3.0+3.0=6.0
+        # 0.5s at value 5 (from 1.5 to 2.0), 1.0s at value 10 (from 2.0 to 3.0), 3.0s at value 15 (from 3.0 to 6.0)
+        expected_with_start = (5.0 * 0.5 + 10.0 * 1.0 + 15.0 * 3.0) / 4.5
+        assert abs(result_with_start - expected_with_start) < 1e-10
+
+        # Test that last_window_s is ignored when window_end is explicitly provided
+        result_explicit_end = time_weighted_average(
+            series, None, 4.0, last_window_s=10.0
+        )
+        # Should use from t=1.0 to t=4.0 (ignoring last_window_s=10.0)
+        # 1.0s at value 5 (from 1.0 to 2.0), 1.0s at value 10 (from 2.0 to 3.0), 1.0s at value 15 (from 3.0 to 4.0)
+        expected_explicit_end = (5.0 * 1.0 + 10.0 * 1.0 + 15.0 * 1.0) / 3.0
+        assert abs(result_explicit_end - expected_explicit_end) < 1e-10
+
+    def test_merge_timeseries_dicts_instantaneous_basic(self):
+        """Test merge_timeseries_dicts basic functionality with instantaneous approach."""
+        s1 = InMemoryMetricsStore()
+        s2 = InMemoryMetricsStore()
+
+        s1.add_metrics_point({"metric1": 5, "metric2": 10}, timestamp=1.0)
+        s1.add_metrics_point({"metric1": 7}, timestamp=2.0)
+
+        s2.add_metrics_point({"metric1": 3, "metric3": 20}, timestamp=1.5)
+
+        result = merge_timeseries_dicts(s1.data, s2.data)
+
+        # metric1: s1 starts at 5 (t=1.0), s2 starts at 3 (t=1.5), s1 changes to 7 (t=2.0)
+        expected_metric1 = [
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(1.5, 8.0),  # 5+3=8
+            TimeStampedValue(2.0, 10.0),  # 3+(7-5)=10
+        ]
+        assert_timeseries_equal(result["metric1"], expected_metric1)
+
+        # metric2: only from s1
+        expected_metric2 = [TimeStampedValue(1.0, 10.0)]
+        assert_timeseries_equal(result["metric2"], expected_metric2)
+
+        # metric3: only from s2
+        expected_metric3 = [TimeStampedValue(1.5, 20.0)]
+        assert_timeseries_equal(result["metric3"], expected_metric3)
+
+    def test_merge_instantaneous_vs_windowed_comparison(self):
+        """Compare instantaneous merge vs windowed approach."""
+        # Create test data that highlights the difference
+        s1 = InMemoryMetricsStore()
+        s2 = InMemoryMetricsStore()
+
+        # Replica 1: 10 requests at t=0.1, then 5 at t=0.9
+        s1.add_metrics_point({"requests": 10}, timestamp=0.1)
+        s1.add_metrics_point({"requests": 5}, timestamp=0.9)
+
+        # Replica 2: 3 requests at t=0.5, then 8 at t=1.1
+        s2.add_metrics_point({"requests": 3}, timestamp=0.5)
+        s2.add_metrics_point({"requests": 8}, timestamp=1.1)
+
+        # Instantaneous approach
+        instantaneous = merge_timeseries_dicts(s1.data, s2.data)
+
+        # Instantaneous should have: t=0.1: 10, t=0.5: 13, t=0.9: 8, t=1.1: 13
+        expected_instantaneous = [
+            TimeStampedValue(0.1, 10.0),
+            TimeStampedValue(0.5, 13.0),  # 10+3=13
+            TimeStampedValue(0.9, 8.0),  # 3+(5-10)=8
+            TimeStampedValue(1.1, 13.0),  # 5+(8-3)=13
+        ]
+        assert_timeseries_equal(instantaneous["requests"], expected_instantaneous)
+
+    def test_instantaneous_merge_handles_zero_deltas(self):
+        """Test that zero deltas are properly filtered out."""
+        series1 = [
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(2.0, 5.0),  # No change
+            TimeStampedValue(3.0, 7.0),
+        ]
+        series2 = [
+            TimeStampedValue(1.5, 3.0),
+            TimeStampedValue(2.5, 3.0),  # No change
+        ]
+
+        result = merge_instantaneous_total([series1, series2])
+
+        # Should skip zero deltas
+        expected = [
+            TimeStampedValue(1.0, 5.0),
+            TimeStampedValue(1.5, 8.0),  # 5+3=8
+            TimeStampedValue(3.0, 10.0),  # 8+(7-5)=10
+        ]
+        assert_timeseries_equal(result, expected)
+
+    def test_instantaneous_merge_with_epoch_times(self):
+        """Test instantaneous merge with realistic epoch timestamps."""
+
+        # Use realistic epoch times (around current time)
+        base_time = 1703980800.0  # December 30, 2023 16:00:00 UTC
+
+        # Simulate 3 replicas reporting metrics over a 30-second period
+        replica1_series = [
+            TimeStampedValue(base_time + 0.0, 12.0),  # t=0s: 12 running requests
+            TimeStampedValue(base_time + 5.2, 15.0),  # t=5.2s: increased to 15
+            TimeStampedValue(base_time + 18.7, 8.0),  # t=18.7s: dropped to 8
+            TimeStampedValue(base_time + 25.1, 11.0),  # t=25.1s: back up to 11
+        ]
+
+        replica2_series = [
+            TimeStampedValue(base_time + 1.3, 7.0),  # t=1.3s: 7 running requests
+            TimeStampedValue(base_time + 8.9, 9.0),  # t=8.9s: increased to 9
+            TimeStampedValue(base_time + 22.4, 4.0),  # t=22.4s: dropped to 4
+        ]
+
+        replica3_series = [
+            TimeStampedValue(base_time + 3.1, 5.0),  # t=3.1s: 5 running requests
+            TimeStampedValue(base_time + 12.6, 8.0),  # t=12.6s: increased to 8
+            TimeStampedValue(base_time + 20.8, 6.0),  # t=20.8s: dropped to 6
+            TimeStampedValue(base_time + 28.3, 9.0),  # t=28.3s: increased to 9
+        ]
+
+        # Merge all replicas
+        result = merge_instantaneous_total(
+            [replica1_series, replica2_series, replica3_series]
+        )
+
+        # Expected timeline of instantaneous totals:
+        expected = [
+            TimeStampedValue(base_time + 0.0, 12.0),  # r1 starts: 12
+            TimeStampedValue(base_time + 1.3, 19.0),  # r2 starts: 12+7=19
+            TimeStampedValue(base_time + 3.1, 24.0),  # r3 starts: 19+5=24
+            TimeStampedValue(base_time + 5.2, 27.0),  # r1 changes: 24+(15-12)=27
+            TimeStampedValue(base_time + 8.9, 29.0),  # r2 changes: 27+(9-7)=29
+            TimeStampedValue(base_time + 12.6, 32.0),  # r3 changes: 29+(8-5)=32
+            TimeStampedValue(base_time + 18.7, 25.0),  # r1 changes: 32+(8-15)=25
+            TimeStampedValue(base_time + 20.8, 23.0),  # r3 changes: 25+(6-8)=23
+            TimeStampedValue(base_time + 22.4, 18.0),  # r2 changes: 23+(4-9)=18
+            TimeStampedValue(base_time + 25.1, 21.0),  # r1 changes: 18+(11-8)=21
+            TimeStampedValue(base_time + 28.3, 24.0),  # r3 changes: 21+(9-6)=24
+        ]
+
+        assert_timeseries_equal(result, expected)
+
+        # Test time-weighted average over different intervals
+        # Full series average
+        full_avg = time_weighted_average(result, None, None)
+        assert full_avg is not None
+        assert full_avg > 0
+
+        # Average over first 10 seconds
+        early_avg = time_weighted_average(result, base_time, base_time + 10.0)
+        assert early_avg is not None
+
+        # Average over last 10 seconds
+        late_avg = time_weighted_average(result, base_time + 20.0, base_time + 30.0)
+        assert late_avg is not None
+
+        # Verify the averages make sense relative to each other
+        # (early period has higher values, so early_avg should be > late_avg)
+        assert early_avg > late_avg
+
+        print(f"Full series average: {full_avg:.2f}")
+        print(f"Early period average (0-10s): {early_avg:.2f}")
+        print(f"Late period average (20-30s): {late_avg:.2f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Recreated from original PR: https://github.com/ray-project/ray/pull/56306

## Controller Metrics Aggregation + Code Refactoring

### What Changed
- **New Feature**: Added `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER` flag to enable metrics aggregation at controller level using timeseries merging
- **Code Cleanup**: Refactored `get_total_num_requests()` as it was starting to get complicated
- **Enhanced Testing**: Added multi-environment test variants to cover different metrics collection modes

**Fully backward compatible** - existing behavior unchanged when flag ...